### PR TITLE
Issues #14, #15

### DIFF
--- a/SquiggleDraw/SquiggleDraw.pde
+++ b/SquiggleDraw/SquiggleDraw.pde
@@ -137,7 +137,7 @@ void loadMainImage(String inImageName) {
   if (tempheight < 720 + 120)
     tempheight = 720 + 120;
 
-  surface.setSize(p1.width + 150, tempheight);
+  surface.setSize(p1.width + 165, tempheight);
 
   // filter image
   p1.filter(GRAY);
@@ -283,7 +283,6 @@ void createPic() {
     }
 
 
-
     /*
     Step along width of image.
      
@@ -340,34 +339,21 @@ void createPic() {
 
     int x;
 
-    if (reverseRow)
-    {
-      x = p2.width;
-      lastX = p2.width;
-    } else
-    {
-      x = 1;
-      lastX = 1;
-    }
+    x = 1;
+    lastX = 1;
 
+    float[] xPoints = new float[0]; 
+    float[] yPoints = new float[0]; 
 
     while (finalStep == false) { // Iterate over each each x-step in the row
 
-      if (reverseRow)
-      {    // Moving left to right on even rows
-        x -= xstep;
-        if (x - xstep < 1)
-          finalStep = true;
-        else
-          finalStep = false;
-      } else
-      { // Moving right to left as usual
-        x += xstep;
-        if (x + xstep >= p2.width)
-          finalStep = true;
-        else
-          finalStep = false;
-      }
+      // Moving right to left:
+      x += xstep;
+      if (x + xstep >= p2.width)
+        finalStep = true;
+      else
+        finalStep = false;
+
 
       b = (int)alpha(p2.get(x, y));
       b = max(minB, b);
@@ -432,10 +418,22 @@ void createPic() {
             lastPhase = lastPhase + HALF_PI;
             lastAmpl = lastAmpl + amplPerVertex;
 
-            curveVertex(xOffset + scaleFactor * lastX, scaleFactor *(y+sin(lastPhase)*lastAmpl));
+            xPoints =  append(xPoints, xOffset + scaleFactor * lastX); 
+            yPoints =  append(yPoints, scaleFactor *(y+sin(lastPhase)*lastAmpl));
           }
         }
     }
+
+    if (reverseRow)
+    {
+      xPoints = reverse(xPoints);
+      yPoints = reverse(yPoints);
+    }
+
+    for (int i = 0; i < xPoints.length; i++) {
+      curveVertex(xPoints[i], yPoints[i]);
+    }
+
 
     // Add final "extra" point to give splines a consistent visual endpoint:
     if (reverseRow)
@@ -478,7 +476,6 @@ void createPic() {
     endShape();
   }
 }
-
 
 
 void fileSelected(File selection) {


### PR DESCRIPTION
Rework how row reversing is done.

Rows are now calculated identically if reversed or not. We build arrays of X and Y points for each row. Then, we reverse those lists -- to only change the order that the vertices are added to the curve -- if the row should be drawn in reverse order.